### PR TITLE
fix target-spec-json with recent nightly builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,3 +10,4 @@ rustflags = ["-C", "link-arg=-Tlink.x"]
 # Nightly Rust features for building a subset of the standard library
 [unstable]
 build-std = ["core"]
+json-target-spec = true

--- a/riscv32ec-unknown-none-elf.json
+++ b/riscv32ec-unknown-none-elf.json
@@ -14,5 +14,5 @@
     "max-atomic-width": 32,
     "panic-strategy": "abort",
     "relocation-model": "static",
-    "target-pointer-width": "32"
+    "target-pointer-width": 32
 }


### PR DESCRIPTION
target-spec-json was accicentally marked as stable, recent builds have corrected this. So now we have to explicitly tell we would like this feature.

see:
https://github.com/rust-lang/compiler-team/issues/944